### PR TITLE
make version numbers match

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: CoenJacobs
 Tags: woocommerce
 Donate link: http://coenjacobs.me/donate/
 Requires at least: 3.5
-Stable tag: 0.1.1
+Stable tag: 0.2
 Tested up to: 4.9.4
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/wc-bundle-style-coupons.php
+++ b/wc-bundle-style-coupons.php
@@ -5,7 +5,7 @@ Plugin Name: WooCommerce Bundle Style Coupons
 Description: Only apply a coupon when all products that this coupon applies to are in cart.
 Author: Coen Jacobs
 Author URI: http://coenjacobs.me
-Version: 0.2-alpha
+Version: 0.2
 */
 
 include( 'includes/class-wc-bundle-style-coupons.php' );


### PR DESCRIPTION
I noticed that the version numbers in the master branch don't match up with the 0.2 that you have in the plugins repo. So now everything is at 0.2.