### PR TITLE
use CRUD and update tested versions

### DIFF
--- a/includes/class-wc-bundle-style-coupons.php
+++ b/includes/class-wc-bundle-style-coupons.php
@@ -28,7 +28,7 @@ class WC_Bundle_Style_Coupons {
 	public function __construct() {
 		add_action( 'init', array( $this, 'load_textdomain_files' ), 10, 0 );
 		add_action( 'woocommerce_coupon_options_usage_restriction', array( $this, 'coupon_options' ), 10, 0 );
-		add_action( 'woocommerce_process_shop_coupon_meta', array( $this, 'process_shop_coupon_meta' ), 10, 2 );
+		add_action( 'woocommerce_coupon_options_save', array( $this, 'process_shop_coupon_meta' ), 10, 2 );
 		add_filter( 'woocommerce_coupon_is_valid', array( $this, 'coupon_is_valid' ), 10, 2 );
 	}
 
@@ -44,9 +44,17 @@ class WC_Bundle_Style_Coupons {
 		) );
 	}
 
-	public function process_shop_coupon_meta( $post_id, $post ) {
+	/**
+	 * Save the new coupon metabox field data
+	 *
+	 * @param integer $post_id
+	 * @param object WC_Coupon $coupon
+	 * @return void
+	 */
+	public function process_shop_coupon_meta( $post_id, $coupon ) {
 		$coupon_bundle = isset( $_POST[ $this->setting_key ] ) ? 'yes' : 'no';
-		update_post_meta( $post_id,  $this->setting_key, $coupon_bundle );
+		$coupon->update_meta_data( $this->setting_key, $coupon_bundle );
+		$coupon->save_meta_data();
 	}
 
 	public function coupon_is_valid( $valid, $coupon ) {

--- a/includes/class-wc-bundle-style-coupons.php
+++ b/includes/class-wc-bundle-style-coupons.php
@@ -71,7 +71,7 @@ class WC_Bundle_Style_Coupons {
 
 		$product_ids = $coupon->get_product_ids();
 
-		if ( 'yes' == get_post_meta( $coupon->get_id(), $this->setting_key, true ) ) {
+		if ( 'yes' == $coupon->get_meta( $this->setting_key, true ) ) {
 			foreach ( wc()->cart->cart_contents as $key => $value ) {
 				if ( in_array( $value['product_id'], $product_ids ) ) {
 					$id_array_key = array_search( $value['product_id'], $product_ids );

--- a/includes/class-wc-bundle-style-coupons.php
+++ b/includes/class-wc-bundle-style-coupons.php
@@ -36,6 +36,9 @@ class WC_Bundle_Style_Coupons {
 		load_plugin_textdomain( 'wc_bundle_style_coupons', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 	}
 
+	/**
+	 * Output the new Coupon metabox field
+	 */
 	public function coupon_options() {
 		woocommerce_wp_checkbox( array(
 			'id'          => $this->setting_key,
@@ -57,6 +60,13 @@ class WC_Bundle_Style_Coupons {
 		$coupon->save_meta_data();
 	}
 
+	/**
+	 * Validate the coupon against the contents of the cart
+	 *
+	 * @param bool $valid
+	 * @param object WC_Coupon $coupon
+	 * @return bool
+	 */
 	public function coupon_is_valid( $valid, $coupon ) {
 
 		$product_ids = $coupon->get_product_ids();

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce
 Donate link: http://coenjacobs.me/donate/
 Requires at least: 3.5
 Stable tag: 0.3
-Tested up to: 5.7.2
+Tested up to: 6.1.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -38,10 +38,10 @@ This plugin uses a per coupon based setting, so you'll have to make a coupon and
 
 == Changelog ==
 
-= 0.3 - 05/17/2021 =
+= 0.3 - 01/12/2003 =
  * Update: Use WooCommerce CRUD to get/set coupon meta.
- * Update: Tested against WooCommerce 5.3
- * Update: Tested against WordPress 5.7.
+ * Update: Tested against WooCommerce 7.4.
+ * Update: Tested against WordPress 6.1.
 
 = 0.2 - 04/30/2018 =
  * Fix: WooCommerce 3.0 compatible

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce
 Donate link: http://coenjacobs.me/donate/
 Requires at least: 3.5
 Stable tag: 0.2
-Tested up to: 4.9.4
+Tested up to: 5.4.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce
 Donate link: http://coenjacobs.me/donate/
 Requires at least: 3.5
 Stable tag: 0.3
-Tested up to: 5.4.0
+Tested up to: 5.7.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -38,7 +38,12 @@ This plugin uses a per coupon based setting, so you'll have to make a coupon and
 
 == Changelog ==
 
-= 0.2 - xx/xx/xxxx =
+= 0.3 - 05/17/2021 =
+ * Update: Use WooCommerce CRUD to get/set coupon meta.
+ * Update: Tested against WooCommerce 5.3
+ * Update: Tested against WordPress 5.7.
+
+= 0.2 - 04/30/2018 =
  * Fix: WooCommerce 3.0 compatible
  * Tweak: Moved class to separate file
  * Tweak: Only load plugin if WooCommerce is active

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: CoenJacobs
 Tags: woocommerce
 Donate link: http://coenjacobs.me/donate/
 Requires at least: 3.5
-Stable tag: 0.2
+Stable tag: 0.3
 Tested up to: 5.4.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/wc-bundle-style-coupons.php
+++ b/wc-bundle-style-coupons.php
@@ -1,12 +1,12 @@
 <?php
 
-/*
-Plugin Name: WooCommerce Bundle Style Coupons
-Description: Only apply a coupon when all products that this coupon applies to are in cart.
-Author: Coen Jacobs
-Author URI: http://coenjacobs.me
-Version: 0.2
-*/
+/**
+ * Plugin Name: WooCommerce Bundle Style Coupons
+ * Description: Only apply a coupon when all products that this coupon applies to are in cart.
+ * Author: Coen Jacobs
+ * Author URI: http://coenjacobs.me
+ * Version: 0.2
+ */
 
 include( 'includes/class-wc-bundle-style-coupons.php' );
 

--- a/wc-bundle-style-coupons.php
+++ b/wc-bundle-style-coupons.php
@@ -5,7 +5,7 @@
  * Description: Only apply a coupon when all products that this coupon applies to are in cart.
  * Author: Coen Jacobs
  * Author URI: http://coenjacobs.me
- * Version: 0.2
+ * Version: 0.3
  * Tested up to: 5.4.0
  * WC requires at least: 3.9.0
  * WC tested up to: 4.1.0

--- a/wc-bundle-style-coupons.php
+++ b/wc-bundle-style-coupons.php
@@ -6,6 +6,9 @@
  * Author: Coen Jacobs
  * Author URI: http://coenjacobs.me
  * Version: 0.2
+ * Tested up to: 5.4.0
+ * WC requires at least: 3.9.0
+ * WC tested up to: 4.1.0
  */
 
 include( 'includes/class-wc-bundle-style-coupons.php' );

--- a/wc-bundle-style-coupons.php
+++ b/wc-bundle-style-coupons.php
@@ -6,9 +6,9 @@
  * Author: Coen Jacobs
  * Author URI: http://coenjacobs.me
  * Version: 0.3
- * Tested up to: 5.4.0
+ * Tested up to: 5.7.2
  * WC requires at least: 3.9.0
- * WC tested up to: 4.1.0
+ * WC tested up to: 5.3.0
  */
 
 include( 'includes/class-wc-bundle-style-coupons.php' );

--- a/wc-bundle-style-coupons.php
+++ b/wc-bundle-style-coupons.php
@@ -6,9 +6,9 @@
  * Author: Coen Jacobs
  * Author URI: http://coenjacobs.me
  * Version: 0.3
- * Tested up to: 5.7.2
+ * Tested up to: 6.1.1
  * WC requires at least: 3.9.0
- * WC tested up to: 5.3.0
+ * WC tested up to: 7.4.0
  */
 
 include( 'includes/class-wc-bundle-style-coupons.php' );


### PR DESCRIPTION
Hi @coenjacobs 👋 I made a tiny tweak to use CRUD on the coupon object instead of post meta. Still appears to be working so I've updated the "Tested against" versions in the plugin header so wordpress.org stops warning people this hasn't been tested in forever. 